### PR TITLE
Update grpo_trainer_gsm.py

### DIFF
--- a/src/open_r1/grpo_trainer_gsm.py
+++ b/src/open_r1/grpo_trainer_gsm.py
@@ -577,7 +577,7 @@ class GRPOTrainer(Trainer):
         if self._signature_columns is None:
             self._signature_columns = ["prompt"]
 
-    def _get_train_sampler(self) -> Sampler:
+    def _get_train_sampler(self, train_dataset: Optional[Dataset] = None) -> Sampler:
         # Returns a sampler that
         # 1. ensures each prompt is repeated across multiple processes. This guarantees that identical prompts are
         #    distributed to different GPUs, allowing rewards to be computed and normalized correctly within each prompt


### PR DESCRIPTION
This commit fixes a TypeError that occurred because the _get_train_sampler method was expected to receive the `train_dataset` (positional) argument but it was missing from the function signature.